### PR TITLE
Azalapa/unsubscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.0] - 2020-07-08
+### Added
+- Configuration parameter websocketTimeout to be used when the connection is halted
+- Method reset all subscriptions and websocket connection
+### Fixed
+- Websocket reconnection when halted with WebSocketTimeoutException
+
 ## [1.1.2] - 2020-03-26
 ### Fixed
 - Websockets now send String ID instead of Int (for compatibility with Hasura and Apollo WS docs compliance)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ this allows to stop subscriptions whenever needed.
 After finishing all subscriptions, the method
 `GraphQLClient.close()` should be called to close correctly the open GQL/websocket connections.
 
+To reset all subscriptions and websocket connection use the method `GraphQLClient.resetSubsConnection()`.
+
 ### To be noted:
 All main methods from the API accept a `variables` param.
 it is a dictionary type and may include variables from your queries or mutations:
@@ -183,3 +185,8 @@ mutation{
   }
 }
 ```
+
+### Websocket timeout:
+You can set a websocket timeout to keep subscriptions alive. 
+
+Use `gql.setTimeoutWebsocket(seconds)`, or directly in the environment `gql.addEnvironment(timeoutWebsocket=seconds)`. Default timeoutWebsocket is 60 seconds

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -355,18 +355,19 @@ class GraphQLClient:
       print('connection not stablished, nothing to reset')
       return False
     if self.sub_router_thread.isAlive(): #check that _sub_routing_loop() is running
-      self.wss_conn_halted = True 
-    else: # in case for some reason _sub_routing_loop() is not running 
-      if self._new_conn():
-        print('WSS Reconnection succeeded, attempting resubscription to lost subs')
-        self._resubscribe_all()
-        print('finished resubscriptions')
-        self.sub_router_thread = threading.Thread(target=self._sub_routing_loop)
-        self.sub_router_thread.start() #start again _sub_routing_loop()
-      else:
-        print('Reconnection has not been possible')
-        return False
-    return True
+      self.wss_conn_halted = True
+      return True
+    # in case for some reason _sub_routing_loop() is not running 
+    if self._new_conn():
+      print('WSS Reconnection succeeded, attempting resubscription to lost subs')
+      self._resubscribe_all()
+      print('finished resubscriptions')
+      self.sub_router_thread = threading.Thread(target=self._sub_routing_loop)
+      self.sub_router_thread.start() #start again _sub_routing_loop()
+      return True
+    else:
+      print('Reconnection has not been possible')
+      return False
 
   # * END SUBSCRIPTION functions ******************************
 

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -390,8 +390,7 @@ class GraphQLClient:
     })
     if default:
       self.setEnvironment(name)
-    if timeoutWebsocket:
-      self.setTimeoutWebsocket(timeoutWebsocket)
+    self.setTimeoutWebsocket(timeoutWebsocket)
 
   def setUrl(self, environment=None, url=None):
     # if environment is not selected, use current environment

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -221,7 +221,7 @@ class GraphQLClient:
         del self.subs[sub_id]
       try:
         message = json.loads(self._conn.recv())
-      except websocket.WebSocketTimeoutException as e:
+      except (TimeoutError, websocket.WebSocketTimeoutException) as e:
         print('Timeout for WSS message exceeded...')
         print(f'original message: {e}')
         self.wss_conn_halted = True

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -79,7 +79,7 @@ class GraphQLClient:
     self.wss_conn_halted = False
     self.closing = False
     self.unsubscribing = False
-    self.websocket_timeout = None
+    self.websocket_timeout = 60
   
   # * with <Object> implementation
   def __enter__(self):

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -351,9 +351,6 @@ class GraphQLClient:
     self._conn.send(json.dumps(payload))
 
   def resetSubsConnection(self):
-    if (self.wss_conn_halted): #check if Connection halted in _sub_routing_loop()
-      print('Reconnection is already trying')
-      return True
     if not self.sub_router_thread:
       print('connection not stablished, nothing to reset')
       return False

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -79,6 +79,7 @@ class GraphQLClient:
     self.wss_conn_halted = False
     self.closing = False
     self.unsubscribing = False
+    self.websocket_timeout = None
   
   # * with <Object> implementation
   def __enter__(self):
@@ -220,7 +221,7 @@ class GraphQLClient:
         del self.subs[sub_id]
       try:
         message = json.loads(self._conn.recv())
-      except TimeoutError as e:
+      except websocket.WebSocketTimeoutException as e:
         print('Timeout for WSS message exceeded...')
         print(f'original message: {e}')
         self.wss_conn_halted = True
@@ -294,6 +295,8 @@ class GraphQLClient:
     self.ws_url = env.get('wss')
     try:
       self._conn = websocket.create_connection(self.ws_url, subprotocols=[GQL_WS_SUBPROTOCOL])
+      if self.websocket_timeout:
+        self._conn.settimeout(self.websocket_timeout)
       return True
     except:
       print(f'Failed connecting to {self.ws_url}')
@@ -358,7 +361,7 @@ class GraphQLClient:
 
   # * END BATCH function **************************************
   # * helper methods
-  def addEnvironment(self, name, url=None, wss=None, headers={}, default=False):
+  def addEnvironment(self, name, url=None, wss=None, headers={}, default=False, timeoutWebsocket=None):
     self.environments.update({
       name: {
         'url': url,
@@ -368,6 +371,9 @@ class GraphQLClient:
     })
     if default:
       self.setEnvironment(name)
+    if timeoutWebsocket:
+      self.setTimeoutWebsocket(timeoutWebsocket)
+
   def setUrl(self, environment=None, url=None):
     # if environment is not selected, use current environment
     if not environment:
@@ -393,6 +399,11 @@ class GraphQLClient:
     if not env:
       raise Exception(f'selected environment not set ({name})')
     self.environment = name
+
+  def setTimeoutWebsocket(self, seconds):
+    self.websocket_timeout =  seconds
+    if self._conn:
+      self._conn.settimeout(self.websocket_timeout)
 
   # * LOW LEVEL METHODS ----------------------------------
   def execute(self, query, variables=None):

--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -380,7 +380,7 @@ class GraphQLClient:
 
   # * END BATCH function **************************************
   # * helper methods
-  def addEnvironment(self, name, url=None, wss=None, headers={}, default=False, timeoutWebsocket=None):
+  def addEnvironment(self, name, url=None, wss=None, headers={}, default=False, timeoutWebsocket=60):
     self.environments.update({
       name: {
         'url': url,


### PR DESCRIPTION
# Description

### 1.- INRPD-410 Function to reset all subscriptions and websocket connection.

The main use of this function is when the server stops sending data but the websocket connection maintains a keep alive, as in the following image

<img width="1400" alt="Screen Shot 2020-07-02 at 10 23 30" src="https://user-images.githubusercontent.com/31219023/86501667-97d43b80-bd60-11ea-8fb9-d5ba6f848f9f.png">

The method `resetSubsConnection()` uses the `wss_conn_halted` flag when the `sub_router_thread` thread is running.

Otherwise the method tries to create a new websocket connection and start `sub_router_thread` thread again. This is useful when an unhandled exception happen inside the `sub_router_thread` thread, as in the following image

<img width="1267" alt="Screen Shot 2020-07-03 at 19 58 59" src="https://user-images.githubusercontent.com/31219023/86502367-08328b00-bd68-11ea-9ba4-d40ab1a4e549.png">
or 
<img width="1240" alt="Screen Shot 2020-07-03 at 21 38 07" src="https://user-images.githubusercontent.com/31219023/86503654-c0b2fb80-bd75-11ea-92bb-247fced2fd4e.png">


### 2.- Use WebSocketTimeoutException instead TimeoutError exception:

Using `except TimeoutError as e:` the exception never happens on my computer. 
**websocket_client** has a `WebSocketTimeoutException`. It works well when a timeout is configured.

The user can set the timeout using `setTimeoutWebsocket(seconds)` or `addEnvironment(timeoutWebsocket=seconds)`
If the timeout is not configured, the exception will never happen 

Valiot server sends 'keep alive' every 15 seconds (approximately), this kicks the exception if the timeoutWebsocket is greater.

This works when the internet connection is gone
<img width="998" alt="Screen Shot 2020-07-03 at 21 00 46" src="https://user-images.githubusercontent.com/31219023/86503105-6499a880-bd70-11ea-9e02-b52073cd9dc2.png">

 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Whit manual tests. 
Using https://test.valiot.app/  and subscriptions to `datumCreated` and `notificationCreated`
[Using the following script](https://github.com/antoniozlp/testSubscriptions)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules