### PR TITLE
Post Timeout configurable through Env with 60 segs as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.0] - 2022-02-04
+
+### Added
+- Add `post_timeout` configuration to avoid stale POST requests
+
 ## [2.0.4] - 2021-10-29
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ mutation{
   }
 }
 ```
+### Post timeout:
+You can set a post timeout to avoid an inactive process. 
+
+Use `gql.setPostTimeout(seconds)`, or directly in the environment `gql.addEnvironment(post_timeout=seconds)`. Default port_timeout is 60 seconds
 
 ### Websocket timeout:
 You can set a websocket timeout to keep subscriptions alive. 

--- a/pygqlc/__init__.py
+++ b/pygqlc/__init__.py
@@ -7,4 +7,4 @@ from .helper_modules.Singleton import Singleton
 # * Package name:
 name = 'pygqlc'
 # * required here for pypi upload exceptions:
-__version__ = "2.0.4"
+__version__ = "2.1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from socket import timeout
 import pytest
 from pygqlc import GraphQLClient # main package
 
@@ -33,12 +34,15 @@ def gql():
   except EnvironmentError:
     sys.exit("Check your environment variables")
 
+  post_timeout_str = (os.environ.get('POST_TIMEOUT') or '10')
+
   gql = GraphQLClient()
   gql.addEnvironment(
     'dev',
     url=os.environ.get('API'),
     wss=os.environ.get('WSS'),
     headers={'Authorization': os.environ.get('TOKEN')},
+    post_timeout=int(post_timeout_str),
     default=True)
 
 

--- a/tests/pygqlc/test_environments.py
+++ b/tests/pygqlc/test_environments.py
@@ -45,6 +45,17 @@ def test_add_header_environment(gql):
   # * teardown test (we don't want dummy headers in the test requests)
   gql.environments[env]['headers'] = original_headers
 
+def test_change_post_timeout(gql):
+  import os
+  test_post_timeout = 103
+  env = gql.environment
+  post_timeout = gql.environments[env]['post_timeout']
+  gql.setPostTimeout(post_timeout=test_post_timeout)
+  new_post_timeout = gql.environments[env]['post_timeout']
+  gql.setPostTimeout(post_timeout=post_timeout)  # return Timeout to default
+  assert (new_post_timeout == test_post_timeout) and (post_timeout != new_post_timeout), \
+    'Post timeout should set on current environment as default'
+
 def test_set_bad_environment(gql):
   with pytest.raises(Exception):
     assert gql.setEnvironment('bad_environ'), \


### PR DESCRIPTION
# Description

The `request` library should use a timeout for every request, otherwise there is a possibility that the process will wait indefinitely for a response from a server.

Therefore, this new feature adds the ability to configure the post_timeout through environment variables, having 60 seconds as default.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tests/pygqlc/test_environments.py

![2022-01-24_21-33](https://user-images.githubusercontent.com/18536836/150907834-6663af44-2d45-42b3-a6a8-6e30b5e25f12.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules