### PR TITLE
Azalapa/fix race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.1] - 2022-07-31
+
+### Fix
+- Fixed race condition when a subscription is starting and _sub_routing_loop is running.
+
 ## [3.0.0] - 2022-07-04
 
 ### Changed

--- a/pygqlc/__init__.py
+++ b/pygqlc/__init__.py
@@ -7,4 +7,4 @@ from .helper_modules.Singleton import Singleton
 # * Package name:
 name = 'pygqlc'
 # * required here for pypi upload exceptions:
-__version__ = "3.0.0"
+__version__ = "3.0.1"


### PR DESCRIPTION
# Description

Fix race condition when a subscription is starting and `_sub_routing_loop` is running.

Avoid this type of error
<img width="1119" alt="Screen Shot 2022-07-29 at 17 36 36" src="https://user-images.githubusercontent.com/31219023/182189520-a0fabe38-9622-4da9-9b41-cff1a2fa9389.png">


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- `pipenv run pytest -x` connected to `test.valiot.app`
<img width="1372" alt="Screen Shot 2022-08-01 at 10 20 16" src="https://user-images.githubusercontent.com/31219023/182183128-116ae492-3a2a-437f-8176-7f2f083b62f2.png">

Tested on worker [valiot-template-jobs](https://github.com/valiot/valiot-template-jobs/tree/azalapa/test627)  connected to `test.valiot.app`
- Using `worker.setPollingMode(PollingMode.SUBSCRIPTION)` and `queueType= QueueType.EVENT` job
- 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules