### PR TITLE
fix: guard _get_messages against list data after flatten

### DIFF
--- a/pygqlc/GraphQLClient.py
+++ b/pygqlc/GraphQLClient.py
@@ -361,7 +361,7 @@ class GraphQLClient(metaclass=Singleton):
         """Gets the messages in a mutation. It normally simply takes the
         'messages' key, but if it is a mutation with labels it joins all
         """
-        if not data:
+        if not data or not isinstance(data, dict):
             return []
         if "messages" in data:
             return data["messages"] or []


### PR DESCRIPTION
# Description

`data_flatten()` can return a **list** when the mutation response contains a single key whose value is a list (e.g., `{"createBatch": [{...}, {...}]}`). After flattening, `_get_messages(data)` receives that list and eventually calls `data.values()`, raising:

```
AttributeError: 'list' object has no attribute 'values'
```

The fix adds `isinstance(data, dict)` to the early-return guard in `_get_messages`, so any non-dict result from `data_flatten` is treated as having no messages.

Fixes # (no issue yet)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The crash was observed in production (ragasa-worker, Queue 008). The fix prevents `_get_messages` from attempting `.values()` on a list.

- [x] Manual code review of the flatten → _get_messages call path

**Test Configuration**:
* pygqlc v3.6.0 (main branch)
* Python 3.14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes