### PR TITLE
ci: PyPI trusted-publishing workflow (OIDC, no token)

### DIFF
--- a/.github/workflows/build-and-publish-pypi.yml
+++ b/.github/workflows/build-and-publish-pypi.yml
@@ -1,0 +1,62 @@
+name: Build and publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    # Block runs from forks so a fork cannot mint an OIDC token / publish.
+    if: github.repository == 'valiot/pygqlc'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build sdist and wheel
+        run: |
+          rm -rf dist
+          uv build
+
+      - name: Verify built version matches expected version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          count="$(ls dist/pygqlc-*.tar.gz 2>/dev/null | wc -l)"
+          if [ "${count}" -ne 1 ]; then
+            echo "::error::Expected exactly one sdist in dist/, found ${count}"
+            exit 1
+          fi
+          built="$(ls dist/pygqlc-*.tar.gz | sed -E 's#.*/pygqlc-(.+)\.tar\.gz#\1#')"
+          if [ "${EVENT_NAME}" = "release" ]; then
+            expected="${RELEASE_TAG#v}"
+            source="release tag ${RELEASE_TAG}"
+          else
+            expected="$(uv run --no-project python -c 'import re,pathlib; print(re.search(r"\"([^\"]+)\"", pathlib.Path("pygqlc/__version__.py").read_text()).group(1))')"
+            source="pygqlc/__version__.py"
+          fi
+          echo "Built version:    ${built}"
+          echo "Expected version: ${expected} (from ${source})"
+          if [ "${built}" != "${expected}" ]; then
+            echo "::error::Built version ${built} does not match expected ${expected} (${source})"
+            exit 1
+          fi
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        run: uv publish --trusted-publishing always


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-and-publish-pypi.yml` — the exact filename the PyPI **Trusted Publisher** for `valiot/pygqlc` is configured to trust. Publishing to **public PyPI** now happens via GitHub OIDC: **no API token or password is stored anywhere**.

Replaces the old manual twine/poetry flow. The Poetry→uv migration (#56) left the repo with no publish automation, which is why 3.6.x/3.7.x never reached public PyPI (latest there is 3.5.5).

## How it works

- **Trigger:** a published GitHub Release (`release: [published]`) or manual `workflow_dispatch`. Ordinary pushes/PRs never publish.
- **Build:** `uv build` (sdist + wheel) after a clean `rm -rf dist`.
- **Publish:** `uv publish --trusted-publishing always` — requires OIDC, fails loudly rather than ever prompting for a password.

## Security hardening (from an adversarial review pass)

- `id-token: write` scoped to the publish job only; `contents: read` at both top level and job level (a job-level `permissions` block *replaces* the top-level one).
- Fork guard `if: github.repository == 'valiot/pygqlc'` so a fork can't mint an OIDC token.
- **Unconditional, fail-closed version gate**: the built sdist version must equal the release tag (`vX.Y.Z` → `X.Y.Z`) on release events, or `pygqlc/__version__.py` on manual dispatch — blocks publishing a mismatched/unvalidated artifact.
- No GitHub `environment:` key — your Trusted Publisher was configured with a **blank** environment, so adding one would cause a 403 publisher mismatch. (If you later want required-reviewer protection, set `environment: pypi` here **and** add `pypi` to the Trusted Publisher together.)
- Action versions match `ci.yml` (`actions/checkout@v6`, `astral-sh/setup-uv@v8.1.0`).

## ⚠️ Merge order (important)

`release`-triggered workflows run the copy of the file on the **default branch**. So this must be **merged to `main` before** the `v3.8.0` release is cut — otherwise the release won't publish anything.

**Sequence:** merge this → create the GitHub Release `v3.8.0` → it auto-builds and publishes 3.8.0 to PyPI.

## Follow-ups (non-blocking)

- Actions are pinned to tags, not commit SHAs (matches `ci.yml`); for a publish-capable workflow, SHA-pinning is stronger — worth hardening this + `ci.yml` together.
- `workflow_dispatch` can be run by anyone with write access; consider branch protection / limiting who can dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)